### PR TITLE
Add 3LO authentication to refresh refreshToken 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "todayIFeelServer",
+  "name": "server",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/server.js
+++ b/server.js
@@ -460,6 +460,8 @@ let transporter = nodemailer.createTransport({
       clientId: process.env.OAUTH_CLIENTID,
       clientSecret: process.env.OAUTH_CLIENT_SECRET,
       refreshToken: process.env.OAUTH_REFRESH_TOKEN,
+      accessToken: process.env.OAUTH_ACCESS_TOKEN,
+      expires: 1484314697598,
     },
    });
 transporter.verify((err, success) => {
@@ -467,6 +469,13 @@ err
     ? console.log(err)
     : console.log(`=== Server is ready to take messages: ${success} ===`);
 });
+
+transporter.on("token", (token) => {
+    console.log("A new access token was generated");
+    console.log("User: %s", token.user);    
+    console.log("Access Token: %s", token.accessToken);
+    console.log("Expires: %s", new Date(token.expires));
+  });
 
 app.post("/send", function (req, res) {
     let mailOptions = {


### PR DESCRIPTION
is used to automatically generate a new accessToken. A first attempt to fix expired token / report functionality after 7 days.